### PR TITLE
Increase polling interval

### DIFF
--- a/get.sh
+++ b/get.sh
@@ -13,6 +13,6 @@ do
     sleep 120
   fi
   date
-  echo "Sleep 60"
-  sleep 60
+  echo "Sleep 300"
+  sleep 300
 done


### PR DESCRIPTION
Polling can be done once in 5 minutes, otherwise "Request count limitation exceeded" error is returned by the API.